### PR TITLE
add inspire for correct url in xml

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/codelist/local/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf
+++ b/web/src/main/webapp/WEB-INF/data/config/codelist/local/thesauri/theme/httpinspireeceuropaeutheme-theme.rdf
@@ -1,0 +1,417 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <skos:ConceptScheme xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme">
+    <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">GEMET - INSPIRE themes, version 1.0</dc:title>
+    <dcterms:issued xmlns:dcterms="http://purl.org/dc/terms/">2008-06-01</dcterms:issued>
+    <dcterms:modified xmlns:dcterms="http://purl.org/dc/terms/">2008-06-01</dcterms:modified>
+  </skos:ConceptScheme>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ad">
+    <skos:prefLabel xml:lang="en">Addresses</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Location of properties based on address identifiers, usually by road name, house number, postal code.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Adressen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Lokalisierung von Grundstücken anhand von Adressdaten, in der Regel Straßenname, Hausnummer und Postleitzahl.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Adresses</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Localisation des propriétés fondée sur les identifiants des adresses, habituellement le nom de la rue, le numéro de la maison et le code postal.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Indirizzi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Localizzazione delle proprietà basata su identificatori di indirizzo, in genere nome della via, numero civico, codice postale.</skos:scopeNote>
+    <skos:altLabel>ad</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/au">
+    <skos:prefLabel xml:lang="en">Administrative units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Units of administration, dividing areas where Member States have and/or exercise jurisdictional rights, for local, regional and national governance, separated by administrative boundaries.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Verwaltungseinheiten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Lokale, regionale und nationale Verwaltungseinheiten, die die Gebiete abgrenzen, in denen die Mitgliedstaaten Hoheitsbefugnisse haben und/oder ausüben und die durch Verwaltungsgrenzen voneinander getrennt sind.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Unités administratives</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Unités d'administration séparées par des limites administratives et délimitant les zones dans lesquelles les États membres détiennent et/ou exercent leurs compétences, aux fins de l'administration locale, régionale et nationale.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Unità amministrative</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Unità amministrative di suddivisione delle zone su cui gli Stati membri hanno e/o esercitano la loro giurisdizione a livello locale, regionale e nazionale, delimitate da confini amministrativi.</skos:scopeNote>
+    <skos:altLabel>au</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/rs">
+    <skos:prefLabel xml:lang="en">Coordinate reference systems</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Systems for uniquely referencing spatial information in space as a set of coordinates (x, y, z) and/or latitude and longitude and height, based on a geodetic horizontal and vertical datum.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Koordinatenreferenzsysteme</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Systeme zur eindeutigen räumlichen Referenzierung von Geodaten anhand eines Koordinatensatzes (x, y, z) und/oder Angaben zu Breite, Länge und Höhe auf der Grundlage eines geodätischen horizontalen und vertikalen Datums.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Référentiels de coordonnées</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Systèmes de référencement unique des informations géographiques dans l'espace sous forme d'une série de coordonnées (x, y, z) et/ou la latitude et la longitude et l'altitude, en se fondant sur un point géodésique horizontal et vertical.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Sistemi di coordinate</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Sistemi per referenziare in maniera univoca le informazioni territoriali nello spazio mediante un sistema di coordinate (x, y, z) e/o latitudine e longitudine e quota, sulla base di un dato geodetico orizzontale e verticale.</skos:scopeNote>
+    <skos:altLabel>rs</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/gg">
+    <skos:prefLabel xml:lang="en">Geographical grid systems</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Harmonised multi-resolution grid with a common point of origin and standardised location and size of grid cells.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geografische Gittersysteme</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Harmonisiertes Gittersystem mit Mehrfachauflösung, gemeinsamem Ursprungspunkt und standardisierter Lokalisierung und Größe der Gitterzellen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Systèmes de maillage géographique</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Grille multi-résolution harmonisée avec un point d'origine commun et une localisation ainsi qu'une taille des cellules harmonisées.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Sistemi di griglie geografiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Griglia multi-risoluzione armonizzata con un punto di origine comune e un posizionamento e una dimensione standard delle celle.</skos:scopeNote>
+    <skos:altLabel>gg</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/cp">
+    <skos:prefLabel xml:lang="en">Cadastral parcels</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas defined by cadastral registers or equivalent.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Flurstücke/Grundstücke (Katasterparzellen)</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gebiete, die anhand des Grundbuchs oder gleichwertiger Verzeichnisse bestimmt werden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Parcelles cadastrales</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zones définies par les registres cadastraux ou équivalents.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Parcelle catastali</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Aree definite dai registri catastali o equivalenti.</skos:scopeNote>
+    <skos:altLabel>cp</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/gn">
+    <skos:prefLabel xml:lang="en">Geographical names</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Names of areas, regions, localities, cities, suburbs, towns or settlements, or any geographical or topographical feature of public or historical interest.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geografische Bezeichnungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Namen von Gebieten, Regionen, Orten, Großstädten, Vororten, Städten oder Siedlungen sowie jedes geografische oder topografische Merkmal von öffentlichem oder historischem Interesse.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Dénominations géographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Noms de zones, de régions, de localités, de grandes villes, de banlieues, de villes moyennes ou d'implantations, ou tout autre élément géographique ou topographique d'intérêt public ou historique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Nomi geografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Denominazione di aree, regioni, località, città, periferie, paesi o centri abitati, o qualsiasi elemento geografico o topografico di interesse pubblico o storico.</skos:scopeNote>
+    <skos:altLabel>gn</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hy">
+    <skos:prefLabel xml:lang="en">Hydrography</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Hydrographic elements, including marine areas and all other water bodies and items related to them, including river basins and sub-basins. Where appropriate, according to the definitions set out in Directive 2000/60/EC of the European Parliament and of the Council of 23 October 2000 establishing a framework for Community action in the field of water policy (2) and in the form of networks.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Gewässernetz</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Elemente des Gewässernetzes, einschließlich Meeresgebieten und allen sonstigen Wasserkörpern und hiermit verbundenen Teilsystemen, darunter Einzugsgebiete und Teileinzugsgebiete. Gegebenenfalls gemäß den Definitionen der Richtlinie 2000/60/EG des Europäischen Parlaments und des Rates vom 23. Oktober 2000 zur Schaffung eines Ordnungsrahmens für Maßnahmen der Gemeinschaft im Bereich der Wasserpolitik [2] und in Form von Netzen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Hydrographie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Éléments hydrographiques, y compris les zones maritimes ainsi que toutes les autres masses d'eau et les éléments qui y sont liés, y compris les bassins et sous-bassins hydrographiques. Conformes, le cas échéant, aux définitions établies par la directive 2000/60/CE du Parlement européen et du Conseil du 23 octobre 2000 établissant un cadre pour une politique communautaire dans le domaine de l'eau [2] et sous forme de réseaux.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Idrografia</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Elementi idrografici, comprese le zone marine e tutti gli altri corpi ed elementi idrici ad esse correlati, tra cui i bacini e sub bacini idrografici. Eventualmente in conformità delle definizioni contenute nella direttiva 2000/60/CE del Parlamento europeo e del Consiglio, del 23 ottobre 2000, che istituisce un quadro per l'azione comunitaria in materia di acque [2], e sotto forma di reti.</skos:scopeNote>
+    <skos:altLabel>hy</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ps">
+    <skos:prefLabel xml:lang="en">Protected sites</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Area designated or managed within a framework of international, Community and Member States' legislation to achieve specific conservation objectives.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Schutzgebiete</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gebiete, die im Rahmen des internationalen und des gemeinschaftlichen Rechts sowie des Rechts der Mitgliedstaaten ausgewiesen sind oder verwaltet werden, um spezifische Erhaltungsziele zu erreichen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Sites protégés</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zone désignée ou gérée dans un cadre législatif international, communautaire ou national en vue d'atteindre des objectifs spécifiques de conservation.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Siti protetti</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Aree designate o gestite in un quadro legislativo internazionale, comunitario o degli Stati membri per conseguire obiettivi di conservazione specifici.</skos:scopeNote>
+    <skos:altLabel>ps</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/tn">
+    <skos:prefLabel xml:lang="en">Transport networks</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Road, rail, air and water transport networks and related infrastructure. Includes links between different networks. Also includes the trans-European transport network as defined in Decision No 1692/96/EC of the European Parliament and of the Council of 23 July 1996 on Community Guidelines for the development of the trans-European transport network (1) and future revisions of that Decision.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Verkehrsnetze</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Verkehrsnetze und zugehörige Infrastruktureinrichtungen für Straßen-, Schienen- und Luftverkehr sowie Schifffahrt. Umfasst auch die Verbindungen zwischen den verschiedenen Netzen. Umfasst auch das transeuropäische Verkehrsnetz im Sinne der Entscheidung Nr. 1692/96/EG des Europäischen Parlaments und des Rates vom 23. Juli 1996 über gemeinschaftliche Leitlinien für den Aufbau eines transeuropäischen Verkehrsnetzes [1] und künftiger Überarbeitungen dieser Entscheidung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Réseaux de transport</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Réseaux routier, ferroviaire, aérien et navigable ainsi que les infrastructures associées. Sont également incluses les correspondances entre les différents réseaux, ainsi que le réseau transeuropéen de transport tel que défini dans la décision no 1692/96/CE du Parlement européen et du Conseil du 23 juillet 1996 sur les orientations communautaires pour le développement du réseau transeuropéen de transport [1] et les révisions futures de cette décision.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Reti di trasporto</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Reti di trasporto su strada, su rotaia, per via aerea e per vie navigabili e relative infrastrutture. Questa voce comprende i collegamenti tra le varie reti e anche la rete transeuropea di trasporto di cui alla decisione n. 1692/96/CE del Parlamento europeo e del Consiglio, del 23 luglio 1996, sugli orientamenti comunitari per lo sviluppo della rete transeuropee dei trasporti [1] e successive revisioni.</skos:scopeNote>
+    <skos:altLabel>tn</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/el">
+    <skos:prefLabel xml:lang="en">Elevation</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Digital elevation models for land, ice and ocean surface. Includes terrestrial elevation, bathymetry and shoreline.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Höhe</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Digitale Höhenmodelle für Land-, Eis- und Meeresflächen. Dazu gehören Geländemodell, Tiefenmessung und Küstenlinie.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Altitude</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Modèles numériques pour l'altitude des surfaces terrestres, glaciaires et océaniques. Comprend l'altitude terrestre, la bathymétrie et la ligne de rivage.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Elevazione</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Modelli digitali di elevazione per superfici emerse, ghiacci e superfici oceaniche. La voce comprende l’altitudine terrestre, la batimetria e la linea di costa.</skos:scopeNote>
+    <skos:altLabel>el</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ge">
+    <skos:prefLabel xml:lang="en">Geology</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geology characterised according to composition and structure. Includes bedrock, aquifers and geomorphology.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Geologie</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geologische Beschreibung anhand von Zusammensetzung und Struktur. Dies umfasst auch Grundgestein, Grundwasserleiter und Geomorphologie.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Géologie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Géologie caractérisée en fonction de la composition et de la structure. Englobe le substratum rocheux, les aquifères et la géomorphologie.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Geologia</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Classificazione geologica in base alla composizione e alla struttura. Questa voce comprende il basamento roccioso, gli acquiferi e la geomorfologia.</skos:scopeNote>
+    <skos:altLabel>ge</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/lc">
+    <skos:prefLabel xml:lang="en">Land cover</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical and biological cover of the earth's surface including artificial surfaces, agricultural areas, forests, (semi-)natural areas, wetlands, water bodies.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bodenbedeckung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Physische und biologische Bedeckung der Erdoberfläche, einschließlich künstlicher Flächen, landwirtschaftlicher Flächen, Wäldern, natürlicher (naturnaher) Gebiete, Feuchtgebieten und Wasserkörpern.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Occupation des terres</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Couverture physique et biologique de la surface terrestre, y compris les surfaces artificielles, les zones agricoles, les forêts, les zones (semi-)naturelles, les zones humides et les masses d'eau.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Copertura del suolo</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Copertura fisica e biologica della superficie terrestre comprese le superfici artificiali, le zone agricole, i boschi e le foreste, le aree (semi)naturali, le zone umide, i corpi idrici.</skos:scopeNote>
+    <skos:altLabel>lc</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/oi">
+    <skos:prefLabel xml:lang="en">Orthoimagery</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geo-referenced image data of the Earth's surface, from either satellite or airborne sensors.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Orthofotografie</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Georeferenzierte Bilddaten der Erdoberfläche von satelliten- oder luftfahrzeuggestützten Sensoren.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Ortho-imagerie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Images géoréférencées de la surface terrestre, provenant de satellites ou de capteurs aéroportés.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Orto immagini</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Immagini georeferenziate della superficie terrestre prese da satellite o da telesensori.</skos:scopeNote>
+    <skos:altLabel>oi</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/af">
+    <skos:prefLabel xml:lang="en">Agricultural and aquaculture facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Farming equipment and production facilities (including irrigation systems, greenhouses and stables).</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Landwirtschaftliche Anlagen und Aquakulturanlagen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Landwirtschaftliche Anlagen und Produktionsstätten (einschließlich Bewässerungssystemen, Gewächshäusern und Ställen).</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Installations agricoles et aquacoles</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Équipement et installations de production agricoles (y compris les systèmes d'irrigation, les serres et les étables).</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Impianti agricoli e di acquacoltura</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Apparecchiature e impianti di produzione agricola (compresi i sistemi di irrigazione, le serre e le stalle).</skos:scopeNote>
+    <skos:altLabel>af</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/am">
+    <skos:prefLabel xml:lang="en">Area management/restriction/regulation zones and reporting units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas managed, regulated or used for reporting at international, European, national, regional and local levels. Includes dumping sites, restricted areas around drinking water sources, nitrate-vulnerable zones, regulated fairways at sea or large inland waters, areas for the dumping of waste, noise restriction zones, prospecting and mining permit areas, river basin districts, relevant reporting units and coastal zone management areas.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bewirtschaftungsgebiete/Schutzgebiete/geregelte Gebiete und Berichterstattungseinheiten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Auf internationaler, europäischer, nationaler, regionaler und lokaler Ebene bewirtschaftete, geregelte oder zu Zwecken der Berichterstattung herangezogene Gebiete. Dazu zählen Deponien, Trinkwasserschutzgebiete, nitratempfindliche Gebiete, geregelte Fahrwasser auf See oder auf großen Binnengewässern, Gebiete für die Abfallverklappung, Lärmschutzgebiete, für Exploration und Bergbau ausgewiesene Gebiete, Flussgebietseinheiten, entsprechende Berichterstattungseinheiten und Gebiete des Küstenzonenmanagements.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Zones de gestion, de restriction ou de réglementation et unités de déclaration</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zones gérées, réglementées ou utilisées pour les rapports aux niveaux international, européen, national, régional et local. Sont inclus les décharges, les zones restreintes aux alentours des sources d'eau potable, les zones vulnérables aux nitrates, les chenaux réglementés en mer ou les eaux intérieures importantes, les zones destinées à la décharge de déchets, les zones soumises à limitation du bruit, les zones faisant l'objet de permis d'exploration et d'extraction minière, les districts hydrographiques, les unités correspondantes utilisées pour les rapports et les zones de gestion du littoral.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Zone sottoposte a gestione/limitazioni/regolamentazione e unità con obbligo di comunicare dati</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Aree gestite, regolamentate o utilizzate per la comunicazione di dati a livello internazionale, europeo, nazionale, regionale e locale. Sono comprese le discariche, le zone vietate attorno alle sorgenti di acqua potabile, le zone sensibili ai nitrati, le vie navigabili regolamentate in mare o in acque interne di grandi dimensioni, le zone per lo smaltimento dei rifiuti, le zone di limitazione del rumore, le zone in cui sono autorizzate attività di prospezione ed estrazione, i distretti idrografici, le pertinenti unità con obbligo di comunicare dati e le aree in cui vigono piani di gestione delle zone costiere.</skos:scopeNote>
+    <skos:altLabel>am</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ac">
+    <skos:prefLabel xml:lang="en">Atmospheric conditions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions in the atmosphere. Includes spatial data based on measurements, on models or on a combination thereof and includes measurement locations.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Atmosphärische Bedingungen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Physikalische Bedingungen in der Atmosphäre. Dazu zählen Geodaten auf der Grundlage von Messungen, Modellen oder einer Kombination aus beiden sowie Angabe der Messstandorte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Conditions atmosphériques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Conditions physiques dans l'atmosphère. Comprend les données géographiques fondées sur des mesures, sur des modèles ou sur une combinaison des deux, ainsi que les lieux de mesure.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Condizioni atmosferiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Condizioni fisiche dell’atmosfera. Questa voce comprende i dati territoriali basati su misurazioni, su modelli o su una combinazione dei due e comprende i punti di misurazione.</skos:scopeNote>
+    <skos:altLabel>ac</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/br">
+    <skos:prefLabel xml:lang="en">Bio-geographical regions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Areas of relatively homogeneous ecological conditions with common characteristics.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Biogeografische Regionen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gebiete mit relativ homogenen ökologischen Bedingungen und gemeinsamen Merkmalen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Régions biogéographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zones présentant des conditions écologiques relativement homogènes avec des caractéristiques communes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Regioni biogeografiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Aree che presentano condizioni ecologiche relativamente omogenee con caratteristiche comuni.</skos:scopeNote>
+    <skos:altLabel>br</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/bu">
+    <skos:prefLabel xml:lang="en">Buildings</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical location of buildings.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Gebäude</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geografischer Standort von Gebäuden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Bâtiments</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Situation géographique des bâtiments.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Edifici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Localizzazione geografica degli edifici.</skos:scopeNote>
+    <skos:altLabel>bu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/er">
+    <skos:prefLabel xml:lang="en">Energy resources</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Energy resources including hydrocarbons, hydropower, bio-energy, solar, wind, etc., where relevant including depth/height information on the extent of the resource.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Energiequellen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Energiequellen wie Kohlenwasserstoffe, Wasserkraft, Bioenergie, Sonnen- und Windenergie usw., gegebenenfalls mit Tiefen- bzw. Höhenangaben zur Ausdehnung der Energiequelle.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Sources d'énergie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Sources d'énergie comprenant les hydrocarbures, l'énergie hydraulique, la bioénergie, l'énergie solaire, l'énergie éolienne, etc., le cas échéant accompagnées d'informations relatives à la profondeur/la hauteur de la source.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Risorse energetiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Risorse energetiche, compresi gli idrocarburi, l'energia idroelettrica, la bioenergia, l'energia solare, eolica, ecc., ove opportuno anche informazioni, in termini di altezza/profondità, sull'entità della risorsa.</skos:scopeNote>
+    <skos:altLabel>er</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/ef">
+    <skos:prefLabel xml:lang="en">Environmental monitoring facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Location and operation of environmental monitoring facilities includes observation and measurement of emissions, of the state of environmental media and of other ecosystem parameters (biodiversity, ecological conditions of vegetation, etc.) by or on behalf of public authorities.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Umweltüberwachung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Standort und Betrieb von Umweltüberwachungseinrichtungen einschließlich Beobachtung und Messung von Schadstoffen, des Zustands von Umweltmedien und anderen Parametern des Ökosystems (Artenvielfalt, ökologischer Zustand der Vegetation usw.) durch oder im Auftrag von öffentlichen Behörden.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Installations de suivi environnemental</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">La situation et le fonctionnement des installations de suivi environnemental comprennent l'observation et la mesure des émissions, de l'état du milieu environnemental et d'autres paramètres de l'écosystème (biodiversité, conditions écologiques de la végétation, etc.) par les autorités publiques ou pour leur compte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Impianti di monitoraggio ambientale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">L'ubicazione e il funzionamento degli impianti di monitoraggio ambientale comprendono l'osservazione e la misurazione delle emissioni, dello stato dei comparti ambientali e di altri parametri dell'ecosistema (biodiversità, condizioni ecologiche della vegetazione, ecc.) da parte o per conto delle autorità pubbliche.</skos:scopeNote>
+    <skos:altLabel>ef</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hb">
+    <skos:prefLabel xml:lang="en">Habitats and biotopes</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical areas characterised by specific ecological conditions, processes, structure, and (life support) functions that physically support the organisms that live there. Includes terrestrial and aquatic areas distinguished by geographical, abiotic and biotic features, whether entirely natural or semi-natural.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Lebensräume und Biotope</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geografische Gebiete mit spezifischen ökologischen Bedingungen, Prozessen, Strukturen und (lebensunterstützenden) Funktionen als physische Grundlage für dort lebende Organismen. Dies umfasst auch durch geografische, abiotische und biotische Merkmale gekennzeichnete natürliche oder naturnahe terrestrische und aquatische Gebiete.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Habitats et biotopes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zones géographiques ayant des caractéristiques écologiques particulières — conditions, processus, structures et fonctions (de maintien de la vie) — favorables aux organismes qui y vivent. Sont incluses les zones terrestres et aquatiques qui se distinguent par leurs caractéristiques géographiques, abiotiques ou biotiques, qu'elles soient naturelles ou semi-naturelles.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Habitat e biotopi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Aree geografiche caratterizzate da condizioni ecologiche specifiche, processi, strutture e funzioni (di supporto alla vita) che supportano materialmente gli organismi che le abitano. Sono comprese le zone terrestri e acquatiche, interamente naturali o seminaturali, distinte in base agli elementi geografici, abiotici e biotici.</skos:scopeNote>
+    <skos:altLabel>hb</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/hh">
+    <skos:prefLabel xml:lang="en">Human health and safety</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of dominance of pathologies (allergies, cancers, respiratory diseases, etc.), information indicating the effect on health (biomarkers, decline of fertility, epidemics) or well-being of humans (fatigue, stress, etc.) linked directly (air pollution, chemicals, depletion of the ozone layer, noise, etc.) or indirectly (food, genetically modified organisms, etc.) to the quality of the environment.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Gesundheit und Sicherheit</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geografische Verteilung verstärkt auftretender pathologischer Befunde (Allergien, Krebserkrankungen, Erkrankungen der Atemwege usw.), Informationen über Auswirkungen auf die Gesundheit (Biomarker, Rückgang der Fruchtbarkeit, Epidemien) oder auf das Wohlbefinden (Ermüdung, Stress usw.) der Menschen in unmittelbarem Zusammenhang mit der Umweltqualität (Luftverschmutzung, Chemikalien, Abbau der Ozonschicht, Lärm usw.) oder in mittelbarem Zusammenhang mit der Umweltqualität (Nahrung, genetisch veränderte Organismen usw.).</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Santé et sécurité des personnes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Répartition géographique des pathologies dominantes (allergies, cancers, maladies respiratoires, etc.) liées directement (pollution de l'air, produits chimiques, appauvrissement de la couche d'ozone, bruit, etc.) ou indirectement (alimentation, organismes génétiquement modifiés, etc.) à la qualité de l'environnement, et ensemble des informations relatif à l'effet de celle-ci sur la santé des hommes (marqueurs biologiques, déclin de la fertilité, épidémies) ou leur bien-être (fatigue, stress, etc.).</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Salute umana e sicurezza</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Distribuzione geografica della prevalenza di patologie (allergie, tumori, malattie respiratorie, ecc.), le informazioni contenenti indicazioni sugli effetti relativi alla salute (indicatori biologici, riduzione della fertilità e epidemie) o al benessere degli esseri umani (affaticamento, stress, ecc.) in relazione alla qualità dell’ambiente, sia in via diretta (inquinamento atmosferico, sostanze chimiche, riduzione dello strato di ozono, rumore, ecc.) che indiretta (alimentazione, organismi geneticamente modificati, ecc.).</skos:scopeNote>
+    <skos:altLabel>hh</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/lu">
+    <skos:prefLabel xml:lang="en">Land use</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Territory characterised according to its current and future planned functional dimension or socio-economic purpose (e.g. residential, industrial, commercial, agricultural, forestry, recreational).</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Bodennutzung</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Beschreibung von Gebieten anhand ihrer derzeitigen und geplanten künftigen Funktion oder ihres sozioökonomischen Zwecks (z. B. Wohn-, Industrie- oder Gewerbegebiete, land- oder forstwirtschaftliche Flächen, Freizeitgebiete).</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Usage des sols</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Territoire caractérisé selon sa dimension fonctionnelle prévue ou son objet socioéconomique actuel et futur (par exemple, résidentiel, industriel, commercial, agricole, forestier, récréatif).</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Utilizzo del territorio</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Classificazione del territorio in base alla dimensione funzionale o alla destinazione socioeconomica presenti e programmate per il futuro (ad esempio ad uso residenziale, industriale, commerciale, agricolo, silvicolo, ricreativo).</skos:scopeNote>
+    <skos:altLabel>lu</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/mr">
+    <skos:prefLabel xml:lang="en">Mineral resources</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Mineral resources including metal ores, industrial minerals, etc., where relevant including depth/height information on the extent of the resource.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Mineralische Bodenschätze</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Mineralische Bodenschätze wie Metallerze, Industrieminerale usw., gegebenenfalls mit Tiefen- bzw. Höhenangaben zur Ausdehnung der Bodenschätze.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Ressources minérales</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Ressources minérales comprenant les minerais métalliques, les minéraux industriels, etc., le cas échéant accompagnées d'informations relatives à la profondeur/la hauteur de la ressource.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Risorse minerarie</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Risorse minerarie, compresi i minerali metallici, i minerali industriali, ecc., ove opportuno anche informazioni, in termini di altezza/profondità, sull'entità della risorsa.</skos:scopeNote>
+    <skos:altLabel>mr</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/nz">
+    <skos:prefLabel xml:lang="en">Natural risk zones</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Vulnerable areas characterised according to natural hazards (all atmospheric, hydrologic, seismic, volcanic and wildfire phenomena that, because of their location, severity, and frequency, have the potential to seriously affect society), e.g. floods, landslides and subsidence, avalanches, forest fires, earthquakes, volcanic eruptions.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Gebiete mit naturbedingten Risiken</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Gefährdete Gebiete, eingestuft nach naturbedingten Risiken (sämtliche atmosphärischen, hydrologischen, seismischen, vulkanischen Phänomene sowie Naturfeuer, die aufgrund ihres örtlichen Auftretens sowie ihrer Schwere und Häufigkeit signifikante Auswirkungen auf die Gesellschaft haben können), z. B. Überschwemmungen, Erdrutsche und Bodensenkungen, Lawinen, Waldbrände, Erdbeben oder Vulkanausbrüche.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Zones à risque naturel</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Zones sensibles caractérisées en fonction des risques naturels (tous les phénomènes atmosphériques, hydrologiques, sismiques, volcaniques, ainsi que les feux de friche qui peuvent, en raison de leur situation, de leur gravité et de leur fréquence, nuire gravement à la société), tels qu'inondations, glissements et affaissements de terrain, avalanches, incendies de forêts, tremblements de terre et éruptions volcaniques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Zone a rischio naturale</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Zone sensibili caratterizzate in base ai rischi naturali (cioè tutti i fenomeni atmosferici, idrologici, sismici, vulcanici e gli incendi che, per l’ubicazione, la gravità e la frequenza, possono avere un grave impatto sulla società), ad esempio inondazioni, slavine e subsidenze, valanghe, incendi di boschi/foreste, terremoti, eruzioni vulcaniche.</skos:scopeNote>
+    <skos:altLabel>nz</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/of">
+    <skos:prefLabel xml:lang="en">Oceanographic geographical features</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions of oceans (currents, salinity, wave heights, etc.).</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Ozeanografisch-geografische Kennwerte</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Physikalische Bedingungen der Ozeane (Strömungsverhältnisse, Salinität, Wellenhöhe usw.).</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Caractéristiques géographiques océanographiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Conditions physiques des océans (courants, salinité, hauteur des vagues, etc.).</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Elementi geografici oceanografici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Condizioni fisiche degli oceani (correnti, salinità, altezza delle onde, ecc.).</skos:scopeNote>
+    <skos:altLabel>of</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/pd">
+    <skos:prefLabel xml:lang="en">Population distribution — demography</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of people, including population characteristics and activity levels, aggregated by grid, region, administrative unit or other analytical unit.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Verteilung der Bevölkerung — Demografie</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geografische Verteilung der Bevölkerung, einschließlich Bevölkerungsmerkmalen und Tätigkeitsebenen, zusammengefasst nach Gitter, Region, Verwaltungseinheit oder sonstigen analytischen Einheiten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Répartition de la population — démographie</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Répartition géographique des personnes, avec les caractéristiques de population et les niveaux d'activité, regroupées par grille, région, unité administrative ou autre unité analytique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Distribuzione della popolazione — demografia</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Distribuzione geografica della popolazione, comprese le relative caratteristiche ed i livelli di attività, aggregata per griglia, regione, unità amministrativa o altra unità analitica.</skos:scopeNote>
+    <skos:altLabel>pd</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/pf">
+    <skos:prefLabel xml:lang="en">Production and industrial facilities</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Industrial production sites, including installations covered by Council Directive 96/61/EC of 24 September 1996 concerning integrated pollution prevention and control (1) and water abstraction facilities, mining, storage sites.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Produktions- und Industrieanlagen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Standorte für industrielle Produktion, einschließlich durch die Richtlinie 96/61/EG des Rates vom 24. September 1996 über die integrierte Vermeidung und Verminderung der Umweltverschmutzung [1] erfasste Anlagen und Einrichtungen zur Wasserentnahme sowie Bergbau- und Lagerstandorte.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Lieux de production et sites industriels</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Sites de production industrielle, y compris les installations couvertes par la directive 96/61/CE du Conseil du 24 septembre 1996 relative à la prévention et à la réduction intégrées de la pollution [1] et les installations de captage d'eau, d'extraction minière et de stockage.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Produzione e impianti industriali</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Siti di produzione industriale; compresi gli impianti di cui alla direttiva 96/61/CE del Consiglio, del 24 settembre 1996, sulla prevenzione e la riduzione integrate dell'inquinamento [1] e gli impianti di estrazione dell’acqua, le attività estrattive e i siti di stoccaggio.</skos:scopeNote>
+    <skos:altLabel>pf</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/sr">
+    <skos:prefLabel xml:lang="en">Sea regions</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Physical conditions of seas and saline water bodies divided into regions and sub-regions with common characteristics.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Meeresregionen</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Physikalische Bedingungen von Meeren und salzhaltigen Gewässern, aufgeteilt nach Regionen und Teilregionen mit gemeinsamen Merkmalen.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Régions maritimes</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Conditions physiques des mers et des masses d'eau salée divisées en régions et en sous-régions à caractéristiques communes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Regioni marine</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Condizioni fisiche dei mari e dei corpi idrici salmastri suddivisi in regioni e sottoregioni con caratteristiche comuni.</skos:scopeNote>
+    <skos:altLabel>sr</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/so">
+    <skos:prefLabel xml:lang="en">Soil</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Soils and subsoil characterised according to depth, texture, structure and content of particles and organic material, stoniness, erosion, where appropriate mean slope and anticipated water storage capacity.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Boden</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Beschreibung von Boden und Unterboden anhand von Tiefe, Textur, Struktur und Gehalt an Teilchen sowie organischem Material, Steinigkeit, Erosion, gegebenenfalls durchschnittliches Gefälle und erwartete Wasserspeicherkapazität.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Sols</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Sols et sous-sol caractérisés selon leur profondeur, texture, structure et teneur en particules et en matières organiques, pierrosité, érosion, le cas échéant pente moyenne et capacité anticipée de stockage de l'eau.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Suolo</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Caratterizzazione del suolo e del sottosuolo in base a profondità, tessitura (texture), struttura e contenuto delle particelle e della materia organica, pietrosità, erosione, eventualmente pendenza media e capacità prevista di ritenzione dell’acqua.</skos:scopeNote>
+    <skos:altLabel>so</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/sd">
+    <skos:prefLabel xml:lang="en">Species distribution</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Geographical distribution of occurrence of animal and plant species aggregated by grid, region, administrative unit or other analytical unit.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Verteilung der Arten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Geografische Verteilung des Auftretens von Tier- und Pflanzenarten, zusammengefasst in Gittern, Region, Verwaltungseinheit oder sonstigen analytischen Einheiten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Répartition des espèces</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Répartition géographique de l'occurrence des espèces animales et végétales regroupées par grille, région, unité administrative ou autre unité analytique.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Distribuzione delle specie</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Distribuzione geografica delle specie animali e vegetali aggregate per griglia, regione, unità amministrativa o altra unità analitica.</skos:scopeNote>
+    <skos:altLabel>sd</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/su">
+    <skos:prefLabel xml:lang="en">Statistical units</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Units for dissemination or use of statistical information.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Statistische Einheiten</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Einheiten für die Verbreitung oder Verwendung statistischer Daten.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Unités statistiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Unités de diffusion ou d'utilisation d'autres informations statistiques.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Unità statistiche</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Unità per la divulgazione o l'utilizzo di dati statistici.</skos:scopeNote>
+    <skos:altLabel>su</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/us">
+    <skos:prefLabel xml:lang="en">Utility and governmental services</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Includes utility facilities such as sewage, waste management, energy supply and water supply, administrative and social governmental services such as public administrations, civil protection sites, schools and hospitals.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Versorgungswirtschaft und staatliche Dienste</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Versorgungseinrichtungen wie Abwasser- und Abfallentsorgung, Energieversorgung und Wasserversorgung; staatliche Verwaltungs- und Sozialdienste wie öffentliche Verwaltung, Katastrophenschutz, Schulen und Krankenhäuser.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Services d'utilité publique et services publics</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Comprend les installations d'utilité publique, tels que les égouts ou les réseaux et installations liés à la gestion des déchets, à l'approvisionnement énergétique, à l'approvisionnement en eau, ainsi que les services administratifs et sociaux publics, tels que les administrations publiques, les sites de la protection civile, les écoles et les hôpitaux.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Servizi di pubblica utilità e servizi amministrativi</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Sono compresi sia impianti quali gli impianti fognari, di gestione dei rifiuti, di fornitura energetica, e di distribuzione idrica, sia servizi pubblici amministrativi e sociali quali le amministrazioni pubbliche, i siti della protezione civile, le scuole e gli ospedali.</skos:scopeNote>
+    <skos:altLabel>us</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+  <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://inspire.ec.europa.eu/theme/mf">
+    <skos:prefLabel xml:lang="en">Meteorological geographical features</skos:prefLabel>
+    <skos:scopeNote xml:lang="en">Weather conditions and their measurements; precipitation, temperature, evapotranspiration, wind speed and direction.</skos:scopeNote>
+    <skos:prefLabel xml:lang="de">Meteorologisch-geografische Kennwerte</skos:prefLabel>
+    <skos:scopeNote xml:lang="de">Witterungsbedingungen und deren Messung; Niederschlag, Temperatur, Gesamtverdunstung (Evapotranspiration), Windgeschwindigkeit und Windrichtung.</skos:scopeNote>
+    <skos:prefLabel xml:lang="fr">Caractéristiques géographiques météorologiques</skos:prefLabel>
+    <skos:scopeNote xml:lang="fr">Conditions météorologiques et leur mesure: précipitations, température, évapotranspiration, vitesse et direction du vent.</skos:scopeNote>
+    <skos:prefLabel xml:lang="it">Elementi geografici meteorologici</skos:prefLabel>
+    <skos:scopeNote xml:lang="it">Condizioni meteorologiche e relative misurazioni; precipitazioni, temperatura, evapotraspirazione, velocità e direzione dei venti.</skos:scopeNote>
+    <skos:altLabel>mf</skos:altLabel>
+    <skos:inScheme rdf:resource="http://inspire.ec.europa.eu/theme" />
+  </skos:Concept>
+</rdf:RDF>
+


### PR DESCRIPTION
Demand of our partenairs to have correct link in xml to the inspire thesaurus.

Ex: http://geocat.ch/geonetwork/srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&thesaurus=external.theme.inspire-theme&id=http://inspire.ec.europa.eu/theme/hb&lang=fre,ita,eng,ger